### PR TITLE
Fixed Key Encryption

### DIFF
--- a/pkg/ssg/bucket.go
+++ b/pkg/ssg/bucket.go
@@ -57,7 +57,7 @@ func (b *bucket) Expunge(s string) error {
 	log.Debugf(LOG+"expunging %s from bucket", s)
 	if b.encryption != "none" {
 		log.Debugf(LOG+"blobs in bucket %v are encrypted; removing cipher parameters from vault", b.key)
-		if err := b.vault.Delete(s); err != nil {
+		if err := b.vault.Provider.Delete(s); err != nil {
 			return err
 		}
 	}

--- a/pkg/ssg/config/vault.go
+++ b/pkg/ssg/config/vault.go
@@ -5,6 +5,23 @@ package config
 // of the storage gateway.
 //
 type Vault struct {
+	FixedKey struct {
+		Enabled bool   `yaml:"enabled"`
+		PBKDF2  string `yaml:"pbkdf2"`
+		AES128  struct {
+			Key string `yaml:"key"`
+			IV  string `yaml:"iv"`
+		} `yaml:"aes128"`
+		AES192 struct {
+			Key string `yaml:"key"`
+			IV  string `yaml:"iv"`
+		} `yaml:"aes192"`
+		AES256 struct {
+			Key string `yaml:"key"`
+			IV  string `yaml:"iv"`
+		} `yaml:"aes256"`
+	} `yaml:"fixedKey"`
+
 	// Kind identifies what type of secure storage
 	// system this configuration represents.
 	//

--- a/pkg/ssg/server.go
+++ b/pkg/ssg/server.go
@@ -262,6 +262,19 @@ func NewServer(c config.Config) (*Server, error) {
 		if b.Vault == nil {
 			v = vault.Nil
 		} else {
+			v.FixedKey.Enabled = b.Vault.FixedKey.Enabled
+
+			v.FixedKey.PBKDF2 = b.Vault.FixedKey.PBKDF2
+
+			v.FixedKey.Literal.AES128.Key = b.Vault.FixedKey.AES128.Key
+			v.FixedKey.Literal.AES128.IV = b.Vault.FixedKey.AES128.IV
+
+			v.FixedKey.Literal.AES192.Key = b.Vault.FixedKey.AES192.Key
+			v.FixedKey.Literal.AES192.IV = b.Vault.FixedKey.AES192.IV
+
+			v.FixedKey.Literal.AES256.Key = b.Vault.FixedKey.AES256.Key
+			v.FixedKey.Literal.AES256.IV = b.Vault.FixedKey.AES256.IV
+
 			switch b.Vault.Kind {
 			case "hashicorp":
 				log.Infof(LOG+"configuring bucket %v vault backed by hashicorp vault (url=%v, prefix=%v)", b.Key, b.Vault.Hashicorp.URL, b.Vault.Hashicorp.Prefix)
@@ -273,7 +286,7 @@ func NewServer(c config.Config) (*Server, error) {
 				if err != nil {
 					return nil, fmt.Errorf("bucket %v hashicorp vault could not be configured: %s", b.Key, err)
 				}
-				v = candidate
+				v.Provider = candidate
 			}
 		}
 

--- a/pkg/ssg/vault/cipher.go
+++ b/pkg/ssg/vault/cipher.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"strings"
@@ -21,34 +20,6 @@ func parse(in string) (string, string) {
 		return "", ""
 	}
 	return l[0], l[1]
-}
-
-func deriveLiteral(v Vault, keyp string, keysz int, ivp string, ivsz int) ([]byte, []byte, error) {
-	encoded, err := v.Provider.Get(keyp)
-	if err != nil {
-		return nil, nil, err
-	}
-	key, err := hex.DecodeString(string(encoded))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	encoded, err = v.Provider.Get(ivp)
-	if err != nil {
-		return nil, nil, err
-	}
-	iv, err := hex.DecodeString(string(encoded))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(key) != keysz {
-		return nil, nil, fmt.Errorf("insufficient key size (%d bytes): want exactly %d bytes", len(key), keysz)
-	}
-	if len(iv) != ivsz {
-		return nil, nil, fmt.Errorf("insufficient initialization vector size (%d bytes): want exactly %d bytes", len(key), ivsz)
-	}
-	return key, iv, nil
 }
 
 func (c Cipher) stream() (cipher.Stream, cipher.Stream, error) {

--- a/pkg/ssg/vault/derive.go
+++ b/pkg/ssg/vault/derive.go
@@ -4,7 +4,6 @@ import (
 	"crypto/aes"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -117,20 +116,12 @@ func (v Vault) Cipher(alg string) (Cipher, error) {
 }
 
 func deriveLiteral(v Vault, keyp string, keysz int, ivp string, ivsz int) ([]byte, []byte, error) {
-	encoded, err := v.Provider.Get(keyp)
-	if err != nil {
-		return nil, nil, err
-	}
-	key, err := hex.DecodeString(string(encoded))
+	key, err := v.Provider.Get(keyp)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	encoded, err = v.Provider.Get(ivp)
-	if err != nil {
-		return nil, nil, err
-	}
-	iv, err := hex.DecodeString(string(encoded))
+	iv, err := v.Provider.Get(ivp)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ssg/vault/derive.go
+++ b/pkg/ssg/vault/derive.go
@@ -1,0 +1,116 @@
+package vault
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func (v Vault) Cipher(alg string) (Cipher, error) {
+	if !v.FixedKey.Enabled {
+		c := Cipher{Algorithm: alg}
+
+		algorithm, _ := parse(alg)
+		switch algorithm {
+		case "aes128":
+			c.Key = make([]byte, 16)
+			c.IV = make([]byte, aes.BlockSize)
+
+		case "aes192":
+			c.Key = make([]byte, 24)
+			c.IV = make([]byte, aes.BlockSize)
+
+		case "aes256":
+			c.Key = make([]byte, 32)
+			c.IV = make([]byte, aes.BlockSize)
+
+		default:
+			return Cipher{}, fmt.Errorf("unrecognized encryption algorithm: '%s'", alg)
+		}
+
+		if _, err := rand.Read(c.Key); err != nil {
+			return Cipher{}, fmt.Errorf("failed to generate %s encryption key: %s", alg, err)
+		}
+		if _, err := rand.Read(c.IV); err != nil {
+			return Cipher{}, fmt.Errorf("failed to generate %s initialization vector: %s", alg, err)
+		}
+
+		return c, nil
+	}
+
+	c := Cipher{Algorithm: alg}
+	var key, salt []byte
+	if v.FixedKey.PBKDF2 != "" {
+		k, err := v.Provider.Get(v.FixedKey.PBKDF2)
+		if err != nil {
+			return Cipher{}, err
+		}
+		if len(k) < 24 {
+			return Cipher{}, fmt.Errorf("insufficient keying material provided for pbkdf2: only %d bytes found (need at least 24 bytes)", len(k))
+		}
+		key = k[len(k)/3:]
+		salt = k[:len(k)/2]
+	}
+
+	algorithm, _ := parse(alg)
+	switch algorithm {
+	case "aes128":
+		if key != nil && salt != nil {
+			c.Key = pbkdf2.Key(key, salt, 4096, 16, sha256.New)
+			c.IV = pbkdf2.Key(key, salt, 4096, aes.BlockSize, sha256.New)
+			return c, nil
+		}
+
+		if v.FixedKey.Literal.AES128.Key != "" && v.FixedKey.Literal.AES128.IV != "" {
+			key, iv, err := deriveLiteral(v, v.FixedKey.Literal.AES128.Key, 16, v.FixedKey.Literal.AES128.IV, aes.BlockSize)
+			if err != nil {
+				return Cipher{}, err
+			}
+			c.Key = key
+			c.IV = iv
+			return c, nil
+		}
+
+	case "aes192":
+		if key != nil && salt != nil {
+			c.Key = pbkdf2.Key(key, salt, 4096, 24, sha256.New)
+			c.IV = pbkdf2.Key(key, salt, 4096, aes.BlockSize, sha256.New)
+			return c, nil
+		}
+
+		if v.FixedKey.Literal.AES192.Key != "" && v.FixedKey.Literal.AES192.IV != "" {
+			key, iv, err := deriveLiteral(v, v.FixedKey.Literal.AES192.Key, 24, v.FixedKey.Literal.AES192.IV, aes.BlockSize)
+			if err != nil {
+				return Cipher{}, err
+			}
+			c.Key = key
+			c.IV = iv
+			return c, nil
+		}
+
+	case "aes256":
+		if key != nil && salt != nil {
+			c.Key = pbkdf2.Key(key, salt, 4096, 32, sha256.New)
+			c.IV = pbkdf2.Key(key, salt, 4096, aes.BlockSize, sha256.New)
+			return c, nil
+		}
+
+		if v.FixedKey.Literal.AES256.Key != "" && v.FixedKey.Literal.AES256.IV != "" {
+			key, iv, err := deriveLiteral(v, v.FixedKey.Literal.AES256.Key, 32, v.FixedKey.Literal.AES256.IV, aes.BlockSize)
+			if err != nil {
+				return Cipher{}, err
+			}
+			c.Key = key
+			c.IV = iv
+			return c, nil
+		}
+
+	default:
+		return Cipher{}, fmt.Errorf("unrecognized encryption algorithm: '%s'", alg)
+	}
+
+	return Cipher{}, fmt.Errorf("unable to derive %s fixed cipher: no methods left to try", algorithm)
+}

--- a/pkg/ssg/vault/nil.go
+++ b/pkg/ssg/vault/nil.go
@@ -4,18 +4,28 @@ import (
 	"fmt"
 )
 
-var Nil NilVault
+var Nil Vault
 
 type NilVault struct{}
 
-func (NilVault) Set(_ string, _ Cipher) error {
+func (NilVault) Get(_ string) ([]byte, error) {
+	return nil, fmt.Errorf("no vault configured")
+}
+
+func (NilVault) SetCipher(_ string, _ Cipher) error {
 	return fmt.Errorf("no vault configured")
 }
 
-func (NilVault) Get(_ string) (Cipher, error) {
+func (NilVault) GetCipher(_ string) (Cipher, error) {
 	return Cipher{}, fmt.Errorf("no vault configured")
 }
 
 func (NilVault) Delete(_ string) error {
 	return fmt.Errorf("no vault configured")
+}
+
+func init() {
+	Nil = Vault{
+		Provider: NilVault{},
+	}
 }

--- a/pkg/ssg/vaults/hashicorp/vault.go
+++ b/pkg/ssg/vaults/hashicorp/vault.go
@@ -69,13 +69,13 @@ func (v Vault) Get(id string) ([]byte, error) {
 	}
 
 	log.Debugf(LOG+"retrieving raw secret path=%v, key=%v", filepath.Join(v.prefix, id), key)
-	in := make(map[string][]byte)
+	in := make(map[string]string)
 	_, err := v.kv.Get(filepath.Join(v.prefix, id), &in, nil)
 	if err != nil {
 		return nil, err
 	}
 	if v, ok := in[key]; ok {
-		return v, nil
+		return hex.DecodeString(v)
 	}
 	return nil, fmt.Errorf("key %v not found in path %v", key, id)
 }

--- a/t/integration.t
+++ b/t/integration.t
@@ -718,6 +718,12 @@ subtest "fixed-key vault encryption" => sub {
 	$a = sha1('t/tmp/a/first/fixed/key/test');
 	$b = sha1('t/tmp/asecond/fixed/key/test');
 	is $a, $b, 'fixed-key encryption should generate identical outputs for identical inputs';
+
+	upload 'ssg://cluster1/special-provided-key/a/first/provided/key/test', 'main.go';
+	upload 'ssg://cluster1/special-provided-key/asecond/provided/key/test', 'main.go';
+	$a = sha1('t/tmp/a/first/provided/key/test');
+	$b = sha1('t/tmp/asecond/provided/key/test');
+	is $a, $b, 'fixed-key encryption can take a key/iv, rather than deriving it';
 };
 
 done_testing;

--- a/t/setup
+++ b/t/setup
@@ -22,7 +22,11 @@ while [[ $n != 0 ]]; do
     while [[ $n != 0 ]]; do
       if curl --connect-timeout 1 -sf http://127.0.0.1:$PUBLIC_PORT/ >/dev/null; then
         echo "» generating pbkdf2 fixed key at secret/tests/fixed…"
-        docker exec ssg_integration_tests_vault_1 vault kv put secret/tests/fixed key=`dd 2>/dev/null if=/dev/urandom bs=64 count=1 | xxd -ps -c 200 | tr -d '\n'`
+        docker exec ssg_integration_tests_vault_1 vault kv put secret/tests/fixed \
+          key=`dd 2>/dev/null if=/dev/urandom bs=64 count=1 | xxd -ps -c 200 | tr -d '\n'`
+        docker exec ssg_integration_tests_vault_1 vault kv put secret/tests/a/random/aes256 \
+          key=`dd 2>/dev/null if=/dev/urandom bs=32 count=1 | xxd -ps -c 200 | tee rand.key | tr -d '\n'` \
+          iv=`dd  2>/dev/null if=/dev/urandom bs=16 count=1 | xxd -ps -c 200 | tr -d '\n'`
         exit 0
       fi
       sleep 0.1

--- a/t/setup
+++ b/t/setup
@@ -9,6 +9,7 @@ if [[ -z "${SSG_NO_BUILD:-}" ]]; then
   echo "» building SSG API OCI image…"
   docker-compose -p ssg_integration_tests -f t/docker-compose.yml build
 fi
+rm -rf t/tmp/*
 echo "» (re)starting INTEGRATION TEST docker compose infrastructure…"
 docker-compose -p ssg_integration_tests -f t/docker-compose.yml down -v
 docker-compose -p ssg_integration_tests -f t/docker-compose.yml up -d
@@ -20,6 +21,8 @@ while [[ $n != 0 ]]; do
     n=300
     while [[ $n != 0 ]]; do
       if curl --connect-timeout 1 -sf http://127.0.0.1:$PUBLIC_PORT/ >/dev/null; then
+        echo "» generating pbkdf2 fixed key at secret/tests/fixed…"
+        docker exec ssg_integration_tests_vault_1 vault kv put secret/tests/fixed key=`dd 2>/dev/null if=/dev/urandom bs=64 count=1 | xxd -ps -c 200 | tr -d '\n'`
         exit 0
       fi
       sleep 0.1

--- a/t/ssg.yml
+++ b/t/ssg.yml
@@ -35,6 +35,25 @@ buckets:
       fs:
         root: /srv/files
 
+  - key: special-provided-key
+    name: Fixed Key Storage (Provided)
+    description: Where the Key and IV are provided
+    vault:
+      kind: hashicorp
+      fixedKey:
+        enabled: true
+        aes256:
+          key: a/random/aes256:key
+          iv:  a/random/aes256:iv
+      hashicorp:
+        url: http://vault:8200
+        token: ichaeZeeth5ichi1OhxooSahpoo8wa
+        prefix: secret/tests
+    provider:
+      kind: fs
+      fs:
+        root: /srv/files
+
   - key: files
     name: Files
     provider:

--- a/t/ssg.yml
+++ b/t/ssg.yml
@@ -19,6 +19,22 @@ defaultBucket:
       prefix: secret/tests
 
 buckets:
+  - key: special-fixed-key
+    name: Fixed Key Storage
+    vault:
+      kind: hashicorp
+      fixedKey:
+        enabled: true
+        pbkdf2: fixed:key
+      hashicorp:
+        url: http://vault:8200
+        token: ichaeZeeth5ichi1OhxooSahpoo8wa
+        prefix: secret/tests
+    provider:
+      kind: fs
+      fs:
+        root: /srv/files
+
   - key: files
     name: Files
     provider:


### PR DESCRIPTION
Vaults (for storing generated encryption ciphers) can now be set to
'fixed key' mode, where they will derive (or use as-is) keys and ivs for
all supported algorithms.  This allows a site to have zero or more
buckets that do _NOT_ randomize encryption keys, in case that sort of
cipher-stability is important.

Note that derived key/iv pairs are still stored in the vault, to
future-proof the encryption against change or rotation of the fixed
keys, and to foster such behavior.

Fixes #12