### PR TITLE
Static Vault Backend

### DIFF
--- a/pkg/ssg/server.go
+++ b/pkg/ssg/server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/jhunt/ssg/pkg/ssg/vault"
 	"github.com/jhunt/ssg/pkg/ssg/vaults/hashicorp"
+	"github.com/jhunt/ssg/pkg/ssg/vaults/static"
 )
 
 func (s *Server) startUpload(to *url.URL) (*stream, string, error) {
@@ -303,6 +304,14 @@ func NewServer(c config.Config) (*Server, error) {
 				})
 				if err != nil {
 					return nil, fmt.Errorf("bucket %v hashicorp vault could not be configured: %s", b.Key, err)
+				}
+				v.Provider = candidate
+
+			case "static":
+				log.Infof(LOG+"configuring bucket %v vault backed by static, fixed keys", b.Key)
+				candidate, err := static.Configure(v.FixedKey)
+				if err != nil {
+					return nil, fmt.Errorf("bucket %v static vault could not be configured: %s", b.Key, err)
 				}
 				v.Provider = candidate
 			}

--- a/pkg/ssg/vault/nil.go
+++ b/pkg/ssg/vault/nil.go
@@ -8,16 +8,18 @@ var Nil Vault
 
 type NilVault struct{}
 
-func (NilVault) Get(_ string) ([]byte, error) {
-	return nil, fmt.Errorf("no vault configured")
-}
-
 func (NilVault) SetCipher(_ string, _ Cipher) error {
 	return fmt.Errorf("no vault configured")
 }
 
 func (NilVault) GetCipher(_ string) (Cipher, error) {
 	return Cipher{}, fmt.Errorf("no vault configured")
+}
+
+func (NilVault) FixedKeyResolver() FixedKeyResolver {
+	return func(_ string) ([]byte, error) {
+		return nil, fmt.Errorf("no vault configured")
+	}
 }
 
 func (NilVault) Delete(_ string) error {

--- a/pkg/ssg/vault/vault.go
+++ b/pkg/ssg/vault/vault.go
@@ -12,10 +12,16 @@ type Vault struct {
 }
 
 type VaultProvider interface {
-	Get(string) ([]byte, error)
+	FixedKeyResolver() FixedKeyResolver
 	SetCipher(string, Cipher) error
 	GetCipher(string) (Cipher, error)
 	Delete(string) error
+}
+
+type FixedKeyResolver func (in string) ([]byte, error)
+
+var PassThroughResolver FixedKeyResolver = func (in string) ([]byte, error) {
+	return []byte(in), nil
 }
 
 // FixedKeySource represents operator configuration for the

--- a/pkg/ssg/vaults/static/vault.go
+++ b/pkg/ssg/vaults/static/vault.go
@@ -1,0 +1,31 @@
+package static
+
+import (
+	"github.com/jhunt/ssg/pkg/ssg/vault"
+)
+
+type Static struct {
+	fixed vault.FixedKeySource
+}
+
+func Configure(fks vault.FixedKeySource) (Static, error) {
+	return Static{
+		fixed: fks,
+	}, nil
+}
+
+func (s Static) SetCipher(string, vault.Cipher) error {
+	return nil
+}
+
+func (s Static) GetCipher(alg string) (vault.Cipher, error) {
+	return s.fixed.Derive(alg, nil)
+}
+
+func (s Static) FixedKeyResolver() vault.FixedKeyResolver {
+	return vault.PassThroughResolver
+}
+
+func (s Static) Delete(string) error {
+	return nil
+}

--- a/t/integration.t
+++ b/t/integration.t
@@ -722,6 +722,12 @@ subtest "fixed-key vault encryption" => sub { # {{{
 	$a = sha1('t/tmp/a/first/provided/key/test');
 	$b = sha1('t/tmp/asecond/provided/key/test');
 	is $a, $b, 'fixed-key encryption can take a key/iv, rather than deriving it';
+
+	upload 'ssg://cluster1/static-vault/a/first/static/key/test', 'main.go';
+	upload 'ssg://cluster1/static-vault/asecond/static/key/test', 'main.go';
+	$a = sha1('t/tmp/a/first/static/key/test');
+	$b = sha1('t/tmp/asecond/static/key/test');
+	is $a, $b, 'static vaults work without real backing credentials storage';
 };
 # }}}
 

--- a/t/ssg.yml
+++ b/t/ssg.yml
@@ -75,6 +75,18 @@ buckets:
       fs:
         root: /srv/files
 
+  - key: static-vault
+    name: Static Fixed Key
+    vault:
+      kind: static
+      fixedKey:
+        enabled: true
+        pbkdf2: ACh2aighiepohkavaeR7ahroopoh3shaceiyooch2reele2einethuucia5duzab
+    provider:
+      kind: fs
+      fs:
+        root: /srv/files
+
   - key: provided-key
     name: Fixed Key Storage (Provided)
     description: Where the Key and IV are provided


### PR DESCRIPTION
The new 'static' Vault can be used when you want a fixed key, but don't
want to carry around another piece of infrastructure (like a spinning
vault).  This is useful for DR/BCP scenarios where we want to depend on
as little as possible (ideally, just a config).